### PR TITLE
Fix missing systemd unit in VPS deploy

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -44,6 +44,17 @@ jobs:
           source: "backend/build/libs/*.jar"
           target: "/opt/schedule-app/app.jar"
 
+      - name: Install systemd unit
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          passphrase: ${{ secrets.VPS_PASSPHRASE }}
+          port: ${{ secrets.VPS_SSH_PORT }}
+          source: "infra/systemd/schedule-app.service"
+          target: "/etc/systemd/system/schedule-app.service"
+
       - name: Restart service
         uses: appleboy/ssh-action@v1.0.0
         with:
@@ -52,4 +63,7 @@ jobs:
           key: ${{ secrets.VPS_SSH_KEY }}
           passphrase: ${{ secrets.VPS_PASSPHRASE }}
           port: ${{ secrets.VPS_SSH_PORT }}
-          script: sudo systemctl restart schedule-app
+          script: |
+            sudo systemctl daemon-reload
+            sudo systemctl enable schedule-app
+            sudo systemctl restart schedule-app

--- a/docs/NGINX_DEPLOYMENT.md
+++ b/docs/NGINX_DEPLOYMENT.md
@@ -16,8 +16,12 @@ Configuration lives in the `nginx/` directory of the main repository. All change
    ```bash
    scp infra/nginx/nginx.conf $VPS_USER@$VPS_HOST:/etc/nginx/nginx.conf
    scp backend/build/libs/*.jar $VPS_USER@$VPS_HOST:/opt/schedule-app/app.jar
+   scp infra/systemd/schedule-app.service \
+       $VPS_USER@$VPS_HOST:/etc/systemd/system/schedule-app.service
    ```
 2. Подключитесь по SSH и перезапустите сервисы:
    ```bash
-   ssh $VPS_USER@$VPS_HOST 'sudo systemctl restart nginx schedule-app'
+   ssh $VPS_USER@$VPS_HOST '\
+     sudo systemctl daemon-reload && \
+     sudo systemctl restart nginx schedule-app'
    ```

--- a/docs/VPS_DEPLOYMENT.md
+++ b/docs/VPS_DEPLOYMENT.md
@@ -20,6 +20,14 @@ npm --prefix frontend run build
 scp backend/build/libs/*.jar $VPS_USER@$VPS_HOST:/opt/schedule-app/app.jar
 ```
 
+При первом развёртывании также установите systemd‑юнит:
+
+```bash
+scp infra/systemd/schedule-app.service \
+  $VPS_USER@$VPS_HOST:/etc/systemd/system/schedule-app.service
+ssh $VPS_USER@$VPS_HOST 'sudo systemctl daemon-reload && sudo systemctl enable schedule-app'
+```
+
 ## Перезапуск сервиса
 
 На сервере приложение запускается как systemd‑служба `schedule-app`. После обновления файла нужно перезапустить сервис:

--- a/infra/systemd/schedule-app.service
+++ b/infra/systemd/schedule-app.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Schedule App Java Service
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/schedule-app
+EnvironmentFile=/etc/schedule-app.env
+ExecStart=/usr/bin/java -jar /opt/schedule-app/app.jar
+Restart=on-failure
+SuccessExitStatus=143
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- install service unit before restart
- document deployment with the new unit file
- bundle schedule-app.service for manual setups

## Testing
- `cd backend && ./gradlew test`
- `cd frontend && npm ci`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684cdfcca86c8326b3f1077658bbea7a