### PR TITLE
Fix systemd unit path

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -53,7 +53,7 @@ jobs:
           passphrase: ${{ secrets.VPS_PASSPHRASE }}
           port: ${{ secrets.VPS_SSH_PORT }}
           source: "infra/systemd/schedule-app.service"
-          target: "/etc/systemd/system/schedule-app.service"
+          target: "/etc/systemd/system"
 
       - name: Restart service
         uses: appleboy/ssh-action@v1.0.0


### PR DESCRIPTION
## Summary
- correct path for schedule-app service in VPS deployment workflow

## Testing
- `./backend/gradlew -p backend test`
- `./backend/gradlew -p backend spotlessCheck`
- `npm --prefix frontend ci`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ce1e8cdd08326871bd27c2ccae331