### PR TITLE
Fix systemd unit copy path

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -54,6 +54,7 @@ jobs:
           port: ${{ secrets.VPS_SSH_PORT }}
           source: "infra/systemd/schedule-app.service"
           target: "/etc/systemd/system"
+          strip_components: 2
 
       - name: Restart service
         uses: appleboy/ssh-action@v1.0.0


### PR DESCRIPTION
## Summary
- copy `schedule-app.service` without directory prefixes

## Testing
- `./backend/gradlew test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684ce3b4a2dc8326a2198b4eea0b93d6