### PR TITLE
Fix systemd unit copy path

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -42,7 +42,8 @@ jobs:
           passphrase: ${{ secrets.VPS_PASSPHRASE }}
           port: ${{ secrets.VPS_SSH_PORT }}
           source: "backend/build/libs/*.jar"
-          target: "/opt/schedule-app/app.jar"
+          target: "/opt/schedule-app"
+          strip_components: 3
 
       - name: Install systemd unit
         uses: appleboy/scp-action@v0.1.4
@@ -54,6 +55,8 @@ jobs:
           port: ${{ secrets.VPS_SSH_PORT }}
           source: "infra/systemd/schedule-app.service"
           target: "/etc/systemd/system"
+          strip_components: 2
+          overwrite: true
 
       - name: Restart service
         uses: appleboy/ssh-action@v1.0.0
@@ -64,6 +67,7 @@ jobs:
           passphrase: ${{ secrets.VPS_PASSPHRASE }}
           port: ${{ secrets.VPS_SSH_PORT }}
           script: |
+            sudo mv /opt/schedule-app/*.jar /opt/schedule-app/app.jar
             sudo systemctl daemon-reload
             sudo systemctl enable schedule-app
             sudo systemctl restart schedule-app


### PR DESCRIPTION
## Summary
- copy JAR to `/opt/schedule-app`
- allow overwriting existing systemd unit
- rename deployed JAR before restarting service

## Testing
- `./backend/gradlew test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ce3b4a2dc8326a2198b4eea0b93d6