### PR TITLE
Fix systemd copy failure

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -45,6 +45,16 @@ jobs:
           target: "/opt/schedule-app"
           strip_components: 3
 
+      - name: Clean old unit file
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          passphrase: ${{ secrets.VPS_PASSPHRASE }}
+          port: ${{ secrets.VPS_SSH_PORT }}
+          script: sudo rm -rf /etc/systemd/system/schedule-app.service
+
       - name: Install systemd unit
         uses: appleboy/scp-action@v0.1.4
         with:


### PR DESCRIPTION
## Summary
- update deployment workflow to clean existing service unit before copying

## Testing
- `./backend/gradlew spotlessApply test`
- `npm run lint:fix`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684d6779091883269075e5a707255b0c