### PR TITLE
Fix deploy script

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -33,6 +33,18 @@ jobs:
         run: ./gradlew bootJar
         working-directory: backend
 
+      - name: Prepare application directory
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          passphrase: ${{ secrets.VPS_PASSPHRASE }}
+          port: ${{ secrets.VPS_SSH_PORT }}
+          script: |
+            sudo mkdir -p /opt/schedule-app
+            sudo rm -rf /opt/schedule-app/app.jar
+
       - name: Copy JAR to server
         uses: appleboy/scp-action@v0.1.4
         with:


### PR DESCRIPTION
## Summary
- fix jar handling for schedule-app deploy
- add ssh step to prepare folder before copying jar

## Testing
- `./backend/gradlew -p backend spotlessApply test`

------
https://chatgpt.com/codex/tasks/task_e_684d6b4fde6c8326af24a99de00fda01