### PR TITLE
Update deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,23 @@
    ./backend/gradlew clean bootJar
    ```
 
-### Развёртывание на VPS
-Актуальная инструкция находится в [docs/VPS_DEPLOYMENT.md](docs/VPS_DEPLOYMENT.md).
+## Развёртывание на сервере
+Краткая последовательность команд для ручного обновления приложения:
 
+```bash
+npm --prefix frontend ci
+npm --prefix frontend run build
+./backend/gradlew bootJar
 
+scp backend/build/libs/*.jar $VPS_USER@$VPS_HOST:/opt/schedule-app/app.jar
+# при первом запуске копируйте systemd‑юнит
+scp infra/systemd/schedule-app.service \
+  $VPS_USER@$VPS_HOST:/etc/systemd/system/schedule-app.service
+ssh $VPS_USER@$VPS_HOST 'sudo systemctl daemon-reload && sudo systemctl enable schedule-app'
+ssh $VPS_USER@$VPS_HOST 'sudo systemctl restart schedule-app'
+```
+
+Файл с переменными окружения должен находиться на сервере по пути `/etc/schedule-app.env`.
 
 ### Двухфакторная аутентификация
 

--- a/docs/VPS_DEPLOYMENT.md
+++ b/docs/VPS_DEPLOYMENT.md
@@ -1,39 +1,8 @@
 # Развертывание на VPS
 
-Этот документ описывает ручное развёртывание приложения на сервер `crm-cynergy.ru` без Docker.
+Основная последовательность команд приведена в разделе
+[«Развёртывание на сервере»](../README.md#развёртывание-на-сервере) в корневом
+`README.md`. Здесь лишь напоминается расположение системных файлов.
 
-## Сборка
-
-```bash
-npm --prefix frontend ci
-npm --prefix frontend run build
-./backend/gradlew clean bootJar
-```
-
-После выполнения команд исполняемый JAR находится в `backend/build/libs`, а статика React скопирована в `backend/src/main/resources/static`.
-
-## Доставка на сервер
-
-Передайте JAR и конфигурацию на VPS, например с помощью `scp`:
-
-```bash
-scp backend/build/libs/*.jar $VPS_USER@$VPS_HOST:/opt/schedule-app/app.jar
-```
-
-При первом развёртывании также установите systemd‑юнит:
-
-```bash
-scp infra/systemd/schedule-app.service \
-  $VPS_USER@$VPS_HOST:/etc/systemd/system/schedule-app.service
-ssh $VPS_USER@$VPS_HOST 'sudo systemctl daemon-reload && sudo systemctl enable schedule-app'
-```
-
-## Перезапуск сервиса
-
-На сервере приложение запускается как systemd‑служба `schedule-app`. После обновления файла нужно перезапустить сервис:
-
-```bash
-ssh $VPS_USER@$VPS_HOST 'sudo systemctl restart schedule-app'
-```
-
-Переменные окружения хранятся в `/etc/schedule-app.env`. Секреты следует задавать там и ограничивать доступ к файлу.
+- юнит `schedule-app.service` находится в каталоге `infra/systemd`;
+- переменные окружения считываются из `/etc/schedule-app.env` на сервере.


### PR DESCRIPTION
## Summary
- add section "Развёртывание на сервере" to README with build/deploy steps
- reference service and env file paths
- simplify VPS deployment doc and link to README

## Testing
- `cd backend && ./gradlew test`
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684d7c9db5bc832685af1014a948078a