### PR TITLE
Remove outdated DNS bullet

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,5 @@ This directory contains all NGINX related documents. Each file focuses on a spec
 - `NGINX_TRAINING.md` – training materials for developers and SREs.
 - `DNS_SETUP.md` – required DNS records for production deployment.
 - `SMTP_CONFIGURATION.md` – environment variables for outgoing email
-- `../infra/dns` – BIND zone files reflecting the recommended records.
 
 Documentation is reviewed **quarterly**. The SRE Lead tracks outdated sections and opens issues for updates.


### PR DESCRIPTION
## Summary
- remove the bullet referencing `../infra/dns` from the docs index

## Testing
- `./backend/gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_684d91ef973883269f81894b9f5650be