### PR TITLE
Add Maven proxy template

### DIFF
--- a/.mvn/settings.xml.in
+++ b/.mvn/settings.xml.in
@@ -1,0 +1,13 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
+  <proxies>
+    <proxy>
+      <id>proxy</id>
+      <active>true</active>
+      <protocol>http</protocol>
+      <host>${PROXY_HOST}</host>
+      <port>${PROXY_PORT}</port>
+    </proxy>
+  </proxies>
+</settings>


### PR DESCRIPTION
## Summary
- add `.mvn/settings.xml.in` template so proxy script can substitute `PROXY_HOST` and `PROXY_PORT`

## Testing
- `./backend/gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684d92b33c388326b42beff578415b78