### PR TITLE
Fix NotificationLog id type

### DIFF
--- a/backend/src/main/java/com/example/scheduletracker/notification/NotificationLog.java
+++ b/backend/src/main/java/com/example/scheduletracker/notification/NotificationLog.java
@@ -3,6 +3,8 @@ package com.example.scheduletracker.notification;
 import com.example.scheduletracker.entity.Lesson;
 import jakarta.persistence.*;
 import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
@@ -10,8 +12,10 @@ import org.hibernate.type.SqlTypes;
 @Table(name = "notification_log")
 public class NotificationLog {
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+  @GeneratedValue(generator = "UUID")
+  @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+  @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+  private UUID id;
 
   @ManyToOne(optional = false)
   @JoinColumn(name = "lesson_id")
@@ -36,7 +40,7 @@ public class NotificationLog {
     this.status = status;
   }
 
-  public Long getId() {
+  public UUID getId() {
     return id;
   }
 

--- a/backend/src/main/java/com/example/scheduletracker/notification/NotificationLogRepository.java
+++ b/backend/src/main/java/com/example/scheduletracker/notification/NotificationLogRepository.java
@@ -1,8 +1,9 @@
 package com.example.scheduletracker.notification;
 
 import java.time.OffsetDateTime;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface NotificationLogRepository extends JpaRepository<NotificationLog, Long> {
+public interface NotificationLogRepository extends JpaRepository<NotificationLog, UUID> {
   void deleteBySentAtBefore(OffsetDateTime ts);
 }


### PR DESCRIPTION
## Summary
- align `NotificationLog` entity with database schema by switching its `id` to `UUID`
- update `NotificationLogRepository` accordingly

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684dc97f4e2c8326a687f6203d64ec76