### PR TITLE
Serve SPA via nginx

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -120,6 +120,48 @@ jobs:
           strip_components: 2
           overwrite: true
 
+      # 8.1 Upload Nginx config
+      - name: Upload Nginx config
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          passphrase: ${{ secrets.VPS_PASSPHRASE }}
+          port: ${{ secrets.VPS_SSH_PORT }}
+          source: "infra/nginx/crm-synergy.conf"
+          target: "/etc/nginx/sites-available"
+          strip_components: 2
+          overwrite: true
+
+      # 8.2 Deploy frontend
+      - name: Deploy frontend to VPS
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          passphrase: ${{ secrets.VPS_PASSPHRASE }}
+          port: ${{ secrets.VPS_SSH_PORT }}
+          source: "frontend/dist/*"
+          target: "/opt/schedule-app/frontend"
+          strip_components: 2
+          overwrite: true
+
+      # 8.3 Enable site and reload Nginx
+      - name: Reload Nginx
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          passphrase: ${{ secrets.VPS_PASSPHRASE }}
+          port: ${{ secrets.VPS_SSH_PORT }}
+          script: |
+            sudo ln -sf /etc/nginx/sites-available/crm-synergy.conf /etc/nginx/sites-enabled/crm-synergy.conf
+            sudo nginx -t
+            sudo systemctl reload nginx
+
       # 9. Configure environment variables on VPS (including Telegram token)
       - name: Configure environment file on VPS
         uses: appleboy/ssh-action@v1.0.0

--- a/docs/NGINX_DEPLOYMENT.md
+++ b/docs/NGINX_DEPLOYMENT.md
@@ -4,3 +4,32 @@ The project uses a standalone NGINX instance as a reverse proxy in front of the 
 
 Configuration files live on the server and are deployed together with the systemd unit. Cluster manifests are no longer maintained.
 
+The SPA is served directly by NGINX from `/opt/schedule-app/frontend`. Only API requests under `/api/` are proxied to the backend running on port `8080`.
+
+A sample configuration is provided in `infra/nginx/crm-synergy.conf`:
+
+```nginx
+server {
+    listen 80;
+    listen [::]:80;
+    server_name crm-synergy.ru www.crm-synergy.ru;
+
+    root /opt/schedule-app/frontend;
+    index index.html;
+
+    location /api/ {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}
+```
+
+Deploy the file to `/etc/nginx/sites-available/` and create a symlink in `sites-enabled`. After every deployment run `nginx -t` followed by `systemctl reload nginx` to apply the changes.

--- a/infra/nginx/crm-synergy.conf
+++ b/infra/nginx/crm-synergy.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name crm-synergy.ru www.crm-synergy.ru;
+
+    root /opt/schedule-app/frontend;
+    index index.html;
+
+    location /api/ {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- host frontend through nginx and proxy API
- document nginx deployment
- deploy static frontend files and nginx config in CI

## Testing
- `./backend/gradlew test`
- `npm ci && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684dd930920c83268821a018229d67ce