### PR TITLE
Fix frontend deployment order

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -39,31 +39,6 @@ jobs:
         run: npm run build
         working-directory: frontend
 
-      # 3.x Автоматическое деплоя фронтенда на VPS
-      - name: Ensure frontend dir exists on VPS
-        uses: appleboy/ssh-action@v1.0.0
-        with:
-          host: ${{ secrets.VPS_HOST }}
-          username: ${{ secrets.VPS_USER }}
-          key: ${{ secrets.VPS_SSH_KEY }}
-          passphrase: ${{ secrets.VPS_PASSPHRASE }}
-          port: ${{ secrets.VPS_SSH_PORT }}
-          script: |
-            sudo mkdir -p /opt/schedule-app/frontend
-            sudo rm -rf /opt/schedule-app/frontend/*
-
-      - name: Deploy frontend to VPS
-        uses: appleboy/scp-action@v0.1.4
-        with:
-          host: ${{ secrets.VPS_HOST }}
-          username: ${{ secrets.VPS_USER }}
-          key: ${{ secrets.VPS_SSH_KEY }}
-          passphrase: ${{ secrets.VPS_PASSPHRASE }}
-          port: ${{ secrets.VPS_SSH_PORT }}
-          source: "frontend/dist/*"
-          target: "/opt/schedule-app/frontend"
-          strip_components: 2
-          overwrite: true
 
       # 3.1 Copy built frontend into backend static resources
       - name: Copy frontend build into backend static
@@ -160,7 +135,21 @@ jobs:
           strip_components: 2
           overwrite: true
 
-      # 8.2 Enable site and reload Nginx
+      # 8.2 Deploy frontend
+      - name: Deploy frontend to VPS
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          passphrase: ${{ secrets.VPS_PASSPHRASE }}
+          port: ${{ secrets.VPS_SSH_PORT }}
+          source: "frontend/dist/*"
+          target: "/opt/schedule-app/frontend"
+          strip_components: 2
+          overwrite: true
+
+      # 8.3 Enable site and reload Nginx
       - name: Reload Nginx
         uses: appleboy/ssh-action@v1.0.0
         with:


### PR DESCRIPTION
## Summary
- ensure GitHub Actions copies frontend after cleaning target dir

## Testing
- `./backend/gradlew -p backend spotlessApply test`
- `npm run lint:fix && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684de2ea52088326a0166053a85be3d8