### PR TITLE
Fix optional telegram token

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -21,7 +21,7 @@ app:
     from: ${MAIL_FROM}
 
 telegram:
-  bot-token: ${TELEGRAM_BOT_TOKEN}
+  bot-token: ${TELEGRAM_BOT_TOKEN:}
 
 jwt:
   # Use a secure random key in production. Fallback string is suitable for local


### PR DESCRIPTION
## Summary
- avoid startup failure when TELEGRAM_BOT_TOKEN is not set

## Testing
- `./backend/gradlew test --no-daemon`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_684defb1177c83268e7636f4af533c8f