### PR TITLE
Fix login redirect loop

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -12,7 +12,7 @@ export function useApiFetch() {
       const base = (import.meta.env.VITE_API_URL || '/').replace(/\/$/, '');
       const url = `${base}${path}`;
       const res = await fetch(url, { ...options, headers });
-      if (res.status === 401 || res.status === 403) {
+      if (token && (res.status === 401 || res.status === 403)) {
         logout();
       }
       return res;

--- a/frontend/src/auth.tsx
+++ b/frontend/src/auth.tsx
@@ -21,20 +21,18 @@ const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 export const AuthLoader = () => {
   const { token, setUser } = useAuth();
-  const navigate = useNavigate();
   const apiFetch = useApiFetch();
 
   useEffect(() => {
     if (!token) {
       setUser(null);
-      navigate('/login');
       return;
     }
     apiFetch('/api/users/me')
       .then((r) => (r.ok ? r.json() : Promise.reject()))
       .then((u: UserInfo) => setUser(u))
       .catch(() => setUser(null));
-  }, [token, navigate, apiFetch, setUser]);
+  }, [token, apiFetch, setUser]);
 
   return null;
 };


### PR DESCRIPTION
## Summary
- avoid infinite redirects when not logged in
- logout only when we actually had a token

## Testing
- `npm run lint`
- `npm test`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_684e13518bb88326a560a1bd6198eb55