### PR TITLE
Fix build after auth removal

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2,21 +2,18 @@ import { useAuth } from './auth';
 import { useCallback } from 'react';
 
 export function useApiFetch() {
-  const { token, logout } = useAuth();
+  const { logout } = useAuth();
   return useCallback(
     async (path: string, options: RequestInit = {}) => {
       const headers = new Headers(options.headers || {});
-      if (token) {
-        headers.set('Authorization', `Bearer ${token}`);
-      }
       const base = (import.meta.env.VITE_API_URL || '/').replace(/\/$/, '');
       const url = `${base}${path}`;
       const res = await fetch(url, { ...options, headers });
-      if (token && (res.status === 401 || res.status === 403)) {
+      if (res.status === 401 || res.status === 403) {
         logout();
       }
       return res;
     },
-    [token, logout]
+    [logout]
   );
 }

--- a/frontend/src/components/TeacherCalendar.tsx
+++ b/frontend/src/components/TeacherCalendar.tsx
@@ -14,7 +14,7 @@ interface Lesson {
 }
 
 export const TeacherCalendar = () => {
-  const { user, token } = useAuth();
+  const { user } = useAuth();
   const apiFetch = useApiFetch();
   const [events, setEvents] = useState<EventInput[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -38,7 +38,7 @@ export const TeacherCalendar = () => {
         );
       })
       .catch(() => setError('Failed to load lessons'));
-  }, [user, token, apiFetch]);
+  }, [user, apiFetch]);
 
   if (!user) return <div>Loading...</div>;
   if (error) return <div className="text-red-600">{error}</div>;

--- a/frontend/src/components/TwoFaToggle.tsx
+++ b/frontend/src/components/TwoFaToggle.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { useApiFetch } from '../api';
 
 export const TwoFaToggle = () => {
-  const { token, user, setUser } = useAuth();
+  const { user, setUser } = useAuth();
   const [enabled, setEnabled] = useState(false);
   const [secret, setSecret] = useState<string | null>(null);
   const apiFetch = useApiFetch();
@@ -13,7 +13,6 @@ export const TwoFaToggle = () => {
   }, [user]);
 
   const toggle = async () => {
-    if (!token) return;
     if (enabled) {
       await apiFetch('/api/users/me/2fa/disable', {
         method: 'POST',


### PR DESCRIPTION
## Summary
- remove token handling in frontend API helper
- stop referencing token in TeacherCalendar and TwoFaToggle

## Testing
- `npm --prefix frontend run build`
- `npm --prefix frontend run lint`
- `cd backend && ./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684e1b2d0ca88326b5c93c6803cdbf90