### PR TITLE
Fix missing AuthenticationManager bean

### DIFF
--- a/backend/src/main/java/com/example/scheduletracker/config/SecurityConfig.java
+++ b/backend/src/main/java/com/example/scheduletracker/config/SecurityConfig.java
@@ -3,6 +3,8 @@ package com.example.scheduletracker.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -21,5 +23,11 @@ public class SecurityConfig {
   @Bean
   public PasswordEncoder passwordEncoder() {
     return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
+      throws Exception {
+    return configuration.getAuthenticationManager();
   }
 }


### PR DESCRIPTION
## Summary
- wire up AuthenticationManager via AuthenticationConfiguration

## Testing
- `./backend/gradlew -p backend spotlessApply test`
- `npm --prefix frontend run lint:fix`
- `npm --prefix frontend run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e9bebaf7083269e9fda476879df6a