### PR TITLE
Fix auth handling for frontend

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2,10 +2,13 @@ import { useAuth } from './auth';
 import { useCallback } from 'react';
 
 export function useApiFetch() {
-  const { logout } = useAuth();
+  const { token, logout } = useAuth();
   return useCallback(
     async (path: string, options: RequestInit = {}) => {
       const headers = new Headers(options.headers || {});
+      if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+      }
       const base = (import.meta.env.VITE_API_URL || '/').replace(/\/$/, '');
       const url = `${base}${path}`;
       const res = await fetch(url, { ...options, headers });
@@ -14,6 +17,6 @@ export function useApiFetch() {
       }
       return res;
     },
-    [logout]
+    [token, logout]
   );
 }

--- a/frontend/src/components/AuthGate.tsx
+++ b/frontend/src/components/AuthGate.tsx
@@ -1,5 +1,11 @@
 import type { ReactElement } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../auth';
 
 export const AuthGate = ({ children }: { children: ReactElement }) => {
+  const { user, token } = useAuth();
+  const location = useLocation();
+  if (!token) return <Navigate to="/login" state={{ from: location }} replace />;
+  if (!user) return null;
   return children;
 };

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,11 +1,13 @@
 import { useState, type FormEvent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate, useLocation, type Location } from 'react-router-dom';
 import { useAuth } from '../auth';
 import { useApiFetch } from '../api';
 
 export const LoginPage = () => {
   const { login } = useAuth();
   const apiFetch = useApiFetch();
+  const navigate = useNavigate();
+  const location = useLocation();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [code, setCode] = useState('');
@@ -20,8 +22,10 @@ export const LoginPage = () => {
       body: JSON.stringify({ username, password, code }),
     });
     if (res.ok) {
-      const data: { token: string } = await res.json();
-      login(data.token);
+      const data: { token: string; username: string; role: string } = await res.json();
+      await login(data.token);
+      const redirect = (location.state as { from?: Location })?.from?.pathname || '/';
+      navigate(redirect, { replace: true });
     } else {
       setError('Invalid credentials');
     }


### PR DESCRIPTION
## Summary
- implement AuthProvider with token storage and user loading
- attach Authorization header in custom fetch hook
- protect routes with AuthGate
- redirect to dashboard on login success

## Testing
- `npm --prefix frontend run lint`
- `./backend/gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_684e9fa850ac8326bc31c7500ef1fa6f