### PR TITLE
Fix build error due to logout hook order

### DIFF
--- a/frontend/src/auth.tsx
+++ b/frontend/src/auth.tsx
@@ -31,21 +31,30 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [token, setToken] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
 
-  const fetchUser = useCallback(async (tok: string) => {
-    try {
-      const res = await fetch('/api/users/me', {
-        headers: { Authorization: `Bearer ${tok}` },
-      });
-      if (res.ok) {
-        const data: UserInfo = await res.json();
-        setUser(data);
-      } else {
+  const logout = useCallback(() => {
+    localStorage.removeItem('token');
+    setToken(null);
+    setUser(null);
+  }, []);
+
+  const fetchUser = useCallback(
+    async (tok: string) => {
+      try {
+        const res = await fetch('/api/users/me', {
+          headers: { Authorization: `Bearer ${tok}` },
+        });
+        if (res.ok) {
+          const data: UserInfo = await res.json();
+          setUser(data);
+        } else {
+          logout();
+        }
+      } catch {
         logout();
       }
-    } catch {
-      logout();
-    }
-  }, [logout]);
+    },
+    [logout],
+  );
 
   useEffect(() => {
     const stored = localStorage.getItem('token');
@@ -62,12 +71,6 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     setToken(t);
     await fetchUser(t);
   };
-
-  const logout = useCallback(() => {
-    localStorage.removeItem('token');
-    setToken(null);
-    setUser(null);
-  }, []);
 
   const value: AuthContextValue = { user, token, login, logout, setUser };
   return (


### PR DESCRIPTION
## Summary
- move `logout` hook above its first use to avoid `logout` variable hoist issue

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ea50da52c8326ae698b1caecd8bb0