### PR TITLE
fix(ci): deploy SPA bundle to nginx root

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -135,6 +135,19 @@ jobs:
           strip_components: 2
           overwrite: true
 
+      # 9.1 Ensure frontend directory exists on VPS
+      - name: Prepare frontend directory
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          passphrase: ${{ secrets.VPS_PASSPHRASE }}
+          port: ${{ secrets.VPS_SSH_PORT }}
+          script: |
+            sudo mkdir -p /opt/schedule-app/frontend
+            sudo chown -R ${{ secrets.VPS_USER }}:${{ secrets.VPS_USER }} /opt/schedule-app
+
       # 10. Deploy static frontend files
       - name: Deploy frontend to VPS
         run: |
@@ -194,3 +207,20 @@ jobs:
             sudo systemctl daemon-reload
             sudo systemctl enable schedule-app
             sudo systemctl restart schedule-app
+
+      # 14. Verify SPA files and endpoint
+      - name: Smoke test deployment
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          passphrase: ${{ secrets.VPS_PASSPHRASE }}
+          port: ${{ secrets.VPS_SSH_PORT }}
+          script: |
+            test -f /opt/schedule-app/frontend/index.html
+
+      - name: Check public endpoints
+        run: |
+          curl -I http://www.crm-synergy.ru/ | grep "200 OK"
+          curl -I http://www.crm-synergy.ru/assets/ | grep "200"

--- a/README.md
+++ b/README.md
@@ -113,8 +113,16 @@ ssh $VPS_USER@$VPS_HOST 'sudo systemctl restart schedule-app'
 
 Сборка фронтенда (`npm run build`) создаёт каталог `frontend/dist`.
 При деплое workflow автоматически копирует его содержимое в
-`/opt/schedule-app/frontend` через `rsync`. Если нужно выполнить
-обновление вручную, используйте команду:
+`/opt/schedule-app/frontend` через `rsync`. Перед копированием убедитесь,
+что каталог `/opt/schedule-app` принадлежит пользователю, под которым
+выполняется копирование:
+
+```bash
+sudo chown -R $USER:$USER /opt/schedule-app
+```
+
+При использовании `rsync` обязательно указывайте завершающий слэш у обоих
+путей, иначе будет скопирован сам каталог `dist`:
 
 ```bash
 rsync -avz --delete frontend/dist/ $VPS_USER@$VPS_HOST:/opt/schedule-app/frontend/

--- a/infra/nginx/crm-synergy.conf
+++ b/infra/nginx/crm-synergy.conf
@@ -16,8 +16,12 @@ server {
         proxy_set_header   X-Forwarded-Proto $scheme;
     }
 
-    # Serve static files and fallback to index.html for SPA routes
+    # Serve static files and fallback to the Spring Boot app if missing
     location / {
-        try_files $uri $uri/ /index.html;
+        try_files $uri $uri/ /index.html @app;
+    }
+
+    location @app {
+        proxy_pass http://127.0.0.1:8080;
     }
 }


### PR DESCRIPTION
## Summary
- ensure `/opt/schedule-app/frontend` exists and has correct owner
- deploy static bundle with trailing slashes
- add smoke tests checking `index.html` and public URLs
- improve nginx config with backend fallback
- document rsync slashes and directory ownership

## Testing
- `npm --prefix frontend ci`
- `npm --prefix frontend run lint`
- `./backend/gradlew -p backend test`

------
https://chatgpt.com/codex/tasks/task_e_684ec243d6b48326bbcc0db4808afe65